### PR TITLE
Pass correlation Id to SES and CS

### DIFF
--- a/src/Smartlogic.Semaphore.Api/AuthenticatedRequestBuilder.cs
+++ b/src/Smartlogic.Semaphore.Api/AuthenticatedRequestBuilder.cs
@@ -14,6 +14,7 @@ namespace Smartlogic.Semaphore.Api
     {
         private static volatile AuthenticatedRequestBuilder _instance;
         private static readonly object syncRoot = new object();
+        private readonly string _correlationIdHeaderName = "X-Correlation_Id";
 
         private readonly Dictionary<string, TokenResponse> _keyCache = new Dictionary<string, TokenResponse>();
 
@@ -38,7 +39,7 @@ namespace Smartlogic.Semaphore.Api
             }
         }
 
-        public HttpWebRequest Build(Uri serverUrl, string apiKey, ILogger logger)
+        public HttpWebRequest Build(Uri serverUrl, string apiKey, ILogger logger, Guid correlationId)
         {
             var request = (HttpWebRequest) WebRequest.Create(serverUrl);
 
@@ -49,6 +50,11 @@ namespace Smartlogic.Semaphore.Api
             else
             {
                 logger.WriteLow("No authentication header required");
+            }
+
+            if (!(correlationId == default))
+            {
+                request.Headers.Add(_correlationIdHeaderName, correlationId.ToString());
             }
 
             return request;

--- a/src/Smartlogic.Semaphore.Api/AuthenticatedRequestBuilder.cs
+++ b/src/Smartlogic.Semaphore.Api/AuthenticatedRequestBuilder.cs
@@ -38,7 +38,7 @@ namespace Smartlogic.Semaphore.Api
             }
         }
 
-        public HttpWebRequest Build(Uri serverUrl, string apiKey, ILogger logger)
+        public HttpWebRequest Build(Uri serverUrl, string apiKey, ILogger logger, Guid correlationId)
         {
             var request = (HttpWebRequest) WebRequest.Create(serverUrl);
 
@@ -49,6 +49,11 @@ namespace Smartlogic.Semaphore.Api
             else
             {
                 logger.WriteLow("No authentication header required");
+            }
+
+            if (!(correlationId == default))
+            {
+                request.Headers.Add("X-Correlation_Id", correlationId.ToString());
             }
 
             return request;

--- a/src/Smartlogic.Semaphore.Api/AuthenticatedRequestBuilder.cs
+++ b/src/Smartlogic.Semaphore.Api/AuthenticatedRequestBuilder.cs
@@ -38,7 +38,7 @@ namespace Smartlogic.Semaphore.Api
             }
         }
 
-        public HttpWebRequest Build(Uri serverUrl, string apiKey, ILogger logger, Guid correlationId)
+        public HttpWebRequest Build(Uri serverUrl, string apiKey, ILogger logger)
         {
             var request = (HttpWebRequest) WebRequest.Create(serverUrl);
 
@@ -49,11 +49,6 @@ namespace Smartlogic.Semaphore.Api
             else
             {
                 logger.WriteLow("No authentication header required");
-            }
-
-            if (!(correlationId == default))
-            {
-                request.Headers.Add("X-Correlation_Id", correlationId.ToString());
             }
 
             return request;

--- a/src/Smartlogic.Semaphore.Api/ClassificationServer.cs
+++ b/src/Smartlogic.Semaphore.Api/ClassificationServer.cs
@@ -21,7 +21,6 @@ namespace Smartlogic.Semaphore.Api
         private readonly string _apiKey;
         private readonly Uri _serverUrl;
         private readonly int _timeout;
-        private readonly Guid _correlationId;
 
         /// <summary>
         ///     A proxy class used for communicating with an instance of Semaphore Classification Server
@@ -71,18 +70,18 @@ namespace Smartlogic.Semaphore.Api
         }
 
         /// <summary>
-        ///     A proxy class used for communicating with an instance of Semaphore Classification Server
+        ///     Constructs a SearchEnhancement class for use with communicating with a particular instance of Search Enhancement
+        ///     Server
         /// </summary>
         /// <param name="webServiceTimeout">An integer representing the number of seconds to wait before timing out</param>
         /// <param name="serverUrl">
-        ///     An absolute <see cref="Uri" /> indicating the Classification Server endpoint
+        ///     An absolute <see cref="Uri" /> indicating the Search Enhancement Server endpoint
         /// </param>
         /// <param name="logger"></param>
         /// <param name="apiKey">An optional apikey string used for connecting to OAuth 2.0 secured services</param>
-        /// <param name="correlationId">An optional correlationId guid used in logs for better identification</param>
         /// <exception cref="System.ArgumentException">Missing server Url;serverUrl</exception>
         /// <exception cref="ArgumentException"></exception>
-        public ClassificationServer(int webServiceTimeout, Uri serverUrl, ILogger logger, string apiKey = "", Guid correlationId = default) : this(webServiceTimeout, serverUrl, logger)
+        public ClassificationServer(int webServiceTimeout, Uri serverUrl, ILogger logger, string apiKey = "") : this(webServiceTimeout, serverUrl, logger)
         {
             if (!string.IsNullOrEmpty(apiKey))
             {
@@ -93,7 +92,6 @@ namespace Smartlogic.Semaphore.Api
                 }
             }
             _apiKey = apiKey;
-            _correlationId = correlationId;
         }
 
         /// <summary>
@@ -128,7 +126,7 @@ namespace Smartlogic.Semaphore.Api
                 throw new ArgumentException("Filename parameter should not be set unless an associated document is passed via the document parameter",
                     nameof(document));
 
-            WriteMedium("Calling Tagging API (Binary). Item Title={0}, FileName={1}", title, fileName);
+            WriteLow("Calling Tagging API (Binary). Item Title={0}, FileName={1}", title, fileName);
 
             var oFrmFields =
                 new Dictionary<string, string>
@@ -201,8 +199,8 @@ namespace Smartlogic.Semaphore.Api
         public Collection<string> GetClassificationClasses()
         {
             var csClasses = new Collection<string>();
-            var request = AuthenticatedRequestBuilder.Instance.Build(new Uri(_serverUrl + "?operation=LISTRULENETCLASSES"), _apiKey, Logger, _correlationId);
-            WriteMedium("CS Request: " + request.RequestUri, null);
+            var request = AuthenticatedRequestBuilder.Instance.Build(new Uri(_serverUrl + "?operation=LISTRULENETCLASSES"), _apiKey, Logger);
+            WriteLow("CS Request: " + request.RequestUri, null);
             request.Method = "GET";
             request.Timeout = _timeout*1000;
 
@@ -261,8 +259,8 @@ namespace Smartlogic.Semaphore.Api
         public Collection<ClassificationLanguage> GetLanguages()
         {
             var languages = new Collection<ClassificationLanguage>();
-            var request = AuthenticatedRequestBuilder.Instance.Build(new Uri(_serverUrl + "?operation=listlanguages"), _apiKey, Logger, _correlationId);
-            WriteMedium("CS Request: " + request.RequestUri, null);
+            var request = AuthenticatedRequestBuilder.Instance.Build(new Uri(_serverUrl + "?operation=listlanguages"), _apiKey, Logger);
+            WriteLow("CS Request: " + request.RequestUri, null);
 
             request.Method = "GET";
             request.Timeout = _timeout*1000;
@@ -349,8 +347,8 @@ namespace Smartlogic.Semaphore.Api
         public Collection<string> GetTextMiningClasses()
         {
             var csClasses = new Collection<string>();
-            var request = AuthenticatedRequestBuilder.Instance.Build(new Uri(_serverUrl + "?operation=LISTRULENETCLASSES"), _apiKey, Logger, _correlationId);
-            WriteMedium("CS Request: " + request.RequestUri, null);
+            var request = AuthenticatedRequestBuilder.Instance.Build(new Uri(_serverUrl + "?operation=LISTRULENETCLASSES"), _apiKey, Logger);
+            WriteLow("CS Request: " + request.RequestUri, null);
             request.Method = "GET";
             request.Timeout = _timeout*1000;
 
@@ -409,8 +407,8 @@ namespace Smartlogic.Semaphore.Api
         public string GetVersion()
         {
             var result = "0.0.0.0";
-            var request = AuthenticatedRequestBuilder.Instance.Build(new Uri(_serverUrl + "?operation=version"), _apiKey, Logger, _correlationId);
-            WriteMedium("CS Request: " + request.RequestUri, null);
+            var request = AuthenticatedRequestBuilder.Instance.Build(new Uri(_serverUrl + "?operation=version"), _apiKey, Logger);
+            WriteLow("CS Request: " + request.RequestUri, null);
             request.Method = "GET";
             request.Timeout = _timeout*1000;
 
@@ -479,7 +477,7 @@ namespace Smartlogic.Semaphore.Api
                 throw new ArgumentException("Filename parameter should not be set unless an associated document is passed via the document parameter",
                     nameof(document));
 
-            WriteMedium(
+            WriteLow(
                 $"Calling TextMining API (Binary). Item Title={title}, FileName={fileName}",
                 null);
 
@@ -553,9 +551,9 @@ namespace Smartlogic.Semaphore.Api
             var sBoundary = BoundaryString;
             const string newLine = "\r\n";
 
-            WriteMedium($"Classifying data using server Url={_serverUrl}", null);
+            WriteLow($"Classifying data using server Url={_serverUrl}", null);
 
-            var request = AuthenticatedRequestBuilder.Instance.Build(_serverUrl, _apiKey, Logger, _correlationId);
+            var request = AuthenticatedRequestBuilder.Instance.Build(_serverUrl, _apiKey, Logger);
 
             request.ContentType = $"multipart/form-data; boundary={sBoundary}";
             request.Method = "POST";
@@ -578,7 +576,7 @@ namespace Smartlogic.Semaphore.Api
                                     s,
                                     newLine,
                                     formFields[s]);
-                                WriteMedium("Added form-data: name={0}, value={1}", s, formFields[s]);
+                                WriteLow("Added form-data: name={0}, value={1}", s, formFields[s]);
                             }
                         }
 
@@ -610,7 +608,7 @@ namespace Smartlogic.Semaphore.Api
 
                         request.ContentLength = oMs.Length;
 
-                        WriteMedium($"Sending {oMs.Length} bytes", null);
+                        WriteLow($"Sending {oMs.Length} bytes", null);
 
                         using (var s = request.GetRequestStream())
                         {
@@ -622,7 +620,7 @@ namespace Smartlogic.Semaphore.Api
                     oMs.Close();
                 }
 
-                WriteMedium("Requesting the response", null);
+                WriteLow("Requesting the response", null);
                 HttpWebResponse oResponse;
                 try
                 {
@@ -653,7 +651,7 @@ namespace Smartlogic.Semaphore.Api
                     oResponse = (HttpWebResponse) oWeX.Response;
                     if (oResponse == null) throw; //Re-throw the original exception (TimeOut)
                 }
-                WriteMedium(
+                WriteLow(
                     $"API Response Code={oResponse.StatusCode}",
                     null);
 
@@ -666,10 +664,10 @@ namespace Smartlogic.Semaphore.Api
                         oParser = new ClassificationResult(oReader.ReadToEnd());
                     }
                 oResponse.Close();
-                WriteMedium("Closed response", null);
+                WriteLow("Closed response", null);
                 if (oParser != null)
                 {
-                    WriteMedium("Received response: {0}", oParser.Response.OuterXml);
+                    WriteLow("Received response: {0}", oParser.Response.OuterXml);
                 }
                 return oParser;
             }

--- a/src/Smartlogic.Semaphore.Api/ClassificationServer.cs
+++ b/src/Smartlogic.Semaphore.Api/ClassificationServer.cs
@@ -21,6 +21,7 @@ namespace Smartlogic.Semaphore.Api
         private readonly string _apiKey;
         private readonly Uri _serverUrl;
         private readonly int _timeout;
+        private readonly Guid _correlationId;
 
         /// <summary>
         ///     A proxy class used for communicating with an instance of Semaphore Classification Server
@@ -70,18 +71,18 @@ namespace Smartlogic.Semaphore.Api
         }
 
         /// <summary>
-        ///     Constructs a SearchEnhancement class for use with communicating with a particular instance of Search Enhancement
-        ///     Server
+        ///     A proxy class used for communicating with an instance of Semaphore Classification Server
         /// </summary>
         /// <param name="webServiceTimeout">An integer representing the number of seconds to wait before timing out</param>
         /// <param name="serverUrl">
-        ///     An absolute <see cref="Uri" /> indicating the Search Enhancement Server endpoint
+        ///     An absolute <see cref="Uri" /> indicating the Classification Server endpoint
         /// </param>
         /// <param name="logger"></param>
         /// <param name="apiKey">An optional apikey string used for connecting to OAuth 2.0 secured services</param>
+        /// <param name="correlationId">An optional correlationId guid passed to CS for logging purposes to make it easier to trace a request</param>
         /// <exception cref="System.ArgumentException">Missing server Url;serverUrl</exception>
         /// <exception cref="ArgumentException"></exception>
-        public ClassificationServer(int webServiceTimeout, Uri serverUrl, ILogger logger, string apiKey = "") : this(webServiceTimeout, serverUrl, logger)
+        public ClassificationServer(int webServiceTimeout, Uri serverUrl, ILogger logger, string apiKey = "", Guid correlationId = default) : this(webServiceTimeout, serverUrl, logger)
         {
             if (!string.IsNullOrEmpty(apiKey))
             {
@@ -92,6 +93,7 @@ namespace Smartlogic.Semaphore.Api
                 }
             }
             _apiKey = apiKey;
+            _correlationId = correlationId;
         }
 
         /// <summary>
@@ -126,7 +128,7 @@ namespace Smartlogic.Semaphore.Api
                 throw new ArgumentException("Filename parameter should not be set unless an associated document is passed via the document parameter",
                     nameof(document));
 
-            WriteLow("Calling Tagging API (Binary). Item Title={0}, FileName={1}", title, fileName);
+            WriteMedium("Calling Tagging API (Binary). Item Title={0}, FileName={1}", title, fileName);
 
             var oFrmFields =
                 new Dictionary<string, string>
@@ -199,8 +201,8 @@ namespace Smartlogic.Semaphore.Api
         public Collection<string> GetClassificationClasses()
         {
             var csClasses = new Collection<string>();
-            var request = AuthenticatedRequestBuilder.Instance.Build(new Uri(_serverUrl + "?operation=LISTRULENETCLASSES"), _apiKey, Logger);
-            WriteLow("CS Request: " + request.RequestUri, null);
+            var request = AuthenticatedRequestBuilder.Instance.Build(new Uri(_serverUrl + "?operation=LISTRULENETCLASSES"), _apiKey, Logger, _correlationId);
+            WriteMedium("CS Request: " + request.RequestUri, null);
             request.Method = "GET";
             request.Timeout = _timeout*1000;
 
@@ -259,8 +261,8 @@ namespace Smartlogic.Semaphore.Api
         public Collection<ClassificationLanguage> GetLanguages()
         {
             var languages = new Collection<ClassificationLanguage>();
-            var request = AuthenticatedRequestBuilder.Instance.Build(new Uri(_serverUrl + "?operation=listlanguages"), _apiKey, Logger);
-            WriteLow("CS Request: " + request.RequestUri, null);
+            var request = AuthenticatedRequestBuilder.Instance.Build(new Uri(_serverUrl + "?operation=listlanguages"), _apiKey, Logger, _correlationId);
+            WriteMedium("CS Request: " + request.RequestUri, null);
 
             request.Method = "GET";
             request.Timeout = _timeout*1000;
@@ -347,8 +349,8 @@ namespace Smartlogic.Semaphore.Api
         public Collection<string> GetTextMiningClasses()
         {
             var csClasses = new Collection<string>();
-            var request = AuthenticatedRequestBuilder.Instance.Build(new Uri(_serverUrl + "?operation=LISTRULENETCLASSES"), _apiKey, Logger);
-            WriteLow("CS Request: " + request.RequestUri, null);
+            var request = AuthenticatedRequestBuilder.Instance.Build(new Uri(_serverUrl + "?operation=LISTRULENETCLASSES"), _apiKey, Logger, _correlationId);
+            WriteMedium("CS Request: " + request.RequestUri, null);
             request.Method = "GET";
             request.Timeout = _timeout*1000;
 
@@ -407,8 +409,8 @@ namespace Smartlogic.Semaphore.Api
         public string GetVersion()
         {
             var result = "0.0.0.0";
-            var request = AuthenticatedRequestBuilder.Instance.Build(new Uri(_serverUrl + "?operation=version"), _apiKey, Logger);
-            WriteLow("CS Request: " + request.RequestUri, null);
+            var request = AuthenticatedRequestBuilder.Instance.Build(new Uri(_serverUrl + "?operation=version"), _apiKey, Logger, _correlationId);
+            WriteMedium("CS Request: " + request.RequestUri, null);
             request.Method = "GET";
             request.Timeout = _timeout*1000;
 
@@ -477,7 +479,7 @@ namespace Smartlogic.Semaphore.Api
                 throw new ArgumentException("Filename parameter should not be set unless an associated document is passed via the document parameter",
                     nameof(document));
 
-            WriteLow(
+            WriteMedium(
                 $"Calling TextMining API (Binary). Item Title={title}, FileName={fileName}",
                 null);
 
@@ -551,9 +553,9 @@ namespace Smartlogic.Semaphore.Api
             var sBoundary = BoundaryString;
             const string newLine = "\r\n";
 
-            WriteLow($"Classifying data using server Url={_serverUrl}", null);
+            WriteMedium($"Classifying data using server Url={_serverUrl}", null);
 
-            var request = AuthenticatedRequestBuilder.Instance.Build(_serverUrl, _apiKey, Logger);
+            var request = AuthenticatedRequestBuilder.Instance.Build(_serverUrl, _apiKey, Logger, _correlationId);
 
             request.ContentType = $"multipart/form-data; boundary={sBoundary}";
             request.Method = "POST";
@@ -576,7 +578,7 @@ namespace Smartlogic.Semaphore.Api
                                     s,
                                     newLine,
                                     formFields[s]);
-                                WriteLow("Added form-data: name={0}, value={1}", s, formFields[s]);
+                                WriteMedium("Added form-data: name={0}, value={1}", s, formFields[s]);
                             }
                         }
 
@@ -608,7 +610,7 @@ namespace Smartlogic.Semaphore.Api
 
                         request.ContentLength = oMs.Length;
 
-                        WriteLow($"Sending {oMs.Length} bytes", null);
+                        WriteMedium($"Sending {oMs.Length} bytes", null);
 
                         using (var s = request.GetRequestStream())
                         {
@@ -620,7 +622,7 @@ namespace Smartlogic.Semaphore.Api
                     oMs.Close();
                 }
 
-                WriteLow("Requesting the response", null);
+                WriteMedium("Requesting the response", null);
                 HttpWebResponse oResponse;
                 try
                 {
@@ -651,7 +653,7 @@ namespace Smartlogic.Semaphore.Api
                     oResponse = (HttpWebResponse) oWeX.Response;
                     if (oResponse == null) throw; //Re-throw the original exception (TimeOut)
                 }
-                WriteLow(
+                WriteMedium(
                     $"API Response Code={oResponse.StatusCode}",
                     null);
 
@@ -664,10 +666,10 @@ namespace Smartlogic.Semaphore.Api
                         oParser = new ClassificationResult(oReader.ReadToEnd());
                     }
                 oResponse.Close();
-                WriteLow("Closed response", null);
+                WriteMedium("Closed response", null);
                 if (oParser != null)
                 {
-                    WriteLow("Received response: {0}", oParser.Response.OuterXml);
+                    WriteMedium("Received response: {0}", oParser.Response.OuterXml);
                 }
                 return oParser;
             }

--- a/src/Smartlogic.Semaphore.Api/SemanticEnhancement.cs
+++ b/src/Smartlogic.Semaphore.Api/SemanticEnhancement.cs
@@ -26,7 +26,6 @@ namespace Smartlogic.Semaphore.Api
         private readonly string _apiKey;
         private readonly Uri _serverUrl;
         private readonly int _timeout;
-        private readonly Guid _correlationId;
 
         /// <summary>
         ///     Constructs a SearchEnhancement class for use with communicating with a particular instance of Search Enhancement
@@ -95,10 +94,9 @@ namespace Smartlogic.Semaphore.Api
         /// </param>
         /// <param name="logger"></param>
         /// <param name="apiKey">An optional apikey string used for connecting to OAuth 2.0 secured services</param>
-        /// <param name="correlationId">An optional correlationId guid used in logs for better identification</param>
         /// <exception cref="System.ArgumentException">Missing server Url;serverUrl</exception>
         /// <exception cref="ArgumentException"></exception>
-        public SemanticEnhancement(int webServiceTimeout, Uri serverUrl, ILogger logger, string apiKey = "", Guid correlationId = default) : this(webServiceTimeout, serverUrl, logger)
+        public SemanticEnhancement(int webServiceTimeout, Uri serverUrl, ILogger logger, string apiKey = "") : this(webServiceTimeout, serverUrl, logger)
         {
             if (!string.IsNullOrEmpty(apiKey))
             {
@@ -109,9 +107,7 @@ namespace Smartlogic.Semaphore.Api
                 }
             }
             _apiKey = apiKey;
-            _correlationId = correlationId;
         }
-
 
         /// <summary>
         ///     Gets or sets a value indicating whether exceptions should be thown or serialized and returned as XML or JSON. The
@@ -151,7 +147,7 @@ namespace Smartlogic.Semaphore.Api
 
             try
             {
-                WriteMedium("SES Request: " + sb, null);
+                WriteLow("SES Request: " + sb, null);
                 oDoc.LoadXml(GetServerResponse(new Uri(sb.ToString())));
             }
             catch (Exception oX)
@@ -226,7 +222,7 @@ namespace Smartlogic.Semaphore.Api
 
             try
             {
-                WriteMedium("SES Request: " + sb, null);
+                WriteLow("SES Request: " + sb, null);
                 oDoc.LoadXml(GetServerResponse(new Uri(sb.ToString())));
             }
             catch (Exception oX)
@@ -248,9 +244,9 @@ namespace Smartlogic.Semaphore.Api
         {
             var facets = new Dictionary<string, string>();
             var req = new Uri($"{_serverUrl}?TBDB={HttpUtility.UrlEncode(taxonomyIndex)}&TEMPLATE=service.xml&SERVICE=facetslist");
-            WriteMedium("SES Request: " + req, null);
+            WriteLow("SES Request: " + req, null);
 
-            var webRequest = AuthenticatedRequestBuilder.Instance.Build(req, _apiKey, Logger, _correlationId);
+            var webRequest = AuthenticatedRequestBuilder.Instance.Build(req, _apiKey, Logger);
             webRequest.Method = "GET";
             webRequest.Timeout = _timeout*1000;
 
@@ -339,7 +335,7 @@ namespace Smartlogic.Semaphore.Api
 
             try
             {
-                WriteMedium("SES Request: " + sb, null);
+                WriteLow("SES Request: " + sb, null);
                 result = GetServerResponse(new Uri(sb.ToString()));
             }
             catch (Exception oX)
@@ -413,7 +409,7 @@ namespace Smartlogic.Semaphore.Api
             string result;
             try
             {
-                WriteMedium("SES Request: " + sb, null);
+                WriteLow("SES Request: " + sb, null);
                 result = GetServerResponse(new Uri(sb.ToString()));
             }
             catch (Exception oX)
@@ -464,7 +460,7 @@ namespace Smartlogic.Semaphore.Api
 
             try
             {
-                WriteMedium("SES Request: " + sb, null);
+                WriteLow("SES Request: " + sb, null);
                 result = GetServerResponse(new Uri(sb.ToString()));
             }
             catch (Exception oX)
@@ -504,7 +500,7 @@ namespace Smartlogic.Semaphore.Api
 
             try
             {
-                WriteMedium("SES Request: " + query, null);
+                WriteLow("SES Request: " + query, null);
                 result = GetServerResponse(new Uri(query));
             }
             catch (Exception oX)
@@ -620,7 +616,7 @@ namespace Smartlogic.Semaphore.Api
 
             try
             {
-                WriteMedium("SES Request: " + sb, null);
+                WriteLow("SES Request: " + sb, null);
                 result = GetServerResponse(new Uri(sb.ToString()));
             }
             catch (Exception oX)
@@ -655,7 +651,7 @@ namespace Smartlogic.Semaphore.Api
             string result;
             try
             {
-                WriteMedium("SES Request: " + sb, null);
+                WriteLow("SES Request: " + sb, null);
                 result = GetServerResponse(new Uri(sb.ToString()));
             }
             catch (Exception oX)
@@ -705,7 +701,7 @@ namespace Smartlogic.Semaphore.Api
 
             try
             {
-                WriteMedium("SES Request: " + sb, null);
+                WriteLow("SES Request: " + sb, null);
                 result = GetServerResponse(new Uri(sb.ToString()));
             }
             catch (Exception oX)
@@ -756,7 +752,7 @@ namespace Smartlogic.Semaphore.Api
 
             try
             {
-                WriteMedium("SES Request: " + sb, null);
+                WriteLow("SES Request: " + sb, null);
                 oDoc.LoadXml(GetServerResponse(new Uri(sb.ToString())));
             }
             catch (Exception oX)
@@ -816,7 +812,7 @@ namespace Smartlogic.Semaphore.Api
 
             try
             {
-                WriteMedium("SES Request: " + query, null);
+                WriteLow("SES Request: " + query, null);
                 oDoc = XDocument.Parse(GetServerResponse(new Uri(query)));
             }
             catch (Exception oX)
@@ -969,7 +965,7 @@ namespace Smartlogic.Semaphore.Api
 
             try
             {
-                WriteMedium("SES Request: {0}", restUri);
+                WriteLow("SES Request: {0}", restUri);
                 var response = GetServerResponse<Schemas.Structure.Semaphore>(restUri);
                 return response?.Structure;
             }
@@ -992,9 +988,9 @@ namespace Smartlogic.Semaphore.Api
             var indices = new List<string>();
 
             var req = new Uri(_serverUrl + "?TEMPLATE=service.xml&SERVICE=modelslist");
-            WriteMedium("SES Request: " + req, null);
+            WriteLow("SES Request: " + req, null);
 
-            var oRequest = AuthenticatedRequestBuilder.Instance.Build(req, _apiKey, Logger, _correlationId);
+            var oRequest = AuthenticatedRequestBuilder.Instance.Build(req, _apiKey, Logger);
             oRequest.Method = "GET";
             oRequest.Timeout = _timeout*1000;
 
@@ -1053,9 +1049,9 @@ namespace Smartlogic.Semaphore.Api
             var languages = new List<string>();
 
             var req = new Uri(_serverUrl + "?TEMPLATE=service.xml&SERVICE=modelslist");
-            WriteMedium("SES Request: " + req, null);
+            WriteLow("SES Request: " + req, null);
 
-            var oRequest = AuthenticatedRequestBuilder.Instance.Build(req, _apiKey, Logger, _correlationId);
+            var oRequest = AuthenticatedRequestBuilder.Instance.Build(req, _apiKey, Logger);
             oRequest.Method = "GET";
             oRequest.Timeout = _timeout * 1000;
 
@@ -1231,7 +1227,7 @@ namespace Smartlogic.Semaphore.Api
 
             try
             {
-                WriteMedium("SES Request: " + sb, null);
+                WriteLow("SES Request: " + sb, null);
                 oDoc.LoadXml(GetServerResponse(new Uri(sb.ToString())));
             }
             catch (Exception oX)
@@ -1267,7 +1263,7 @@ namespace Smartlogic.Semaphore.Api
 
             try
             {
-                WriteMedium("SES Request: " + sb, null);
+                WriteLow("SES Request: " + sb, null);
                 oDoc.LoadXml(GetServerResponse(new Uri(sb.ToString())));
             }
             catch (Exception oX)
@@ -1321,7 +1317,7 @@ namespace Smartlogic.Semaphore.Api
 
             try
             {
-                WriteMedium("SES Request: " + sb, null);
+                WriteLow("SES Request: " + sb, null);
                 oDoc.LoadXml(GetServerResponse(new Uri(sb.ToString())));
             }
             catch (Exception oX)
@@ -1343,7 +1339,7 @@ namespace Smartlogic.Semaphore.Api
             string response = null;
 
             var req = new Uri(_serverUrl + "?TEMPLATE=service.xml&SERVICE=versions");
-            WriteMedium("SES Request: " + req, null);
+            WriteLow("SES Request: " + req, null);
 
             try
             {
@@ -1452,7 +1448,7 @@ namespace Smartlogic.Semaphore.Api
 
             try
             {
-                WriteMedium("SES Request: " + query, null);
+                WriteLow("SES Request: " + query, null);
                 return GetServerResponse(new Uri(query));
             }
             catch (Exception oX)
@@ -1542,9 +1538,10 @@ namespace Smartlogic.Semaphore.Api
         /// <exception cref="SemaphoreConnectionException"></exception>
         private string GetServerResponse(Uri serverWithQuery)
         {
-            var oRequest = AuthenticatedRequestBuilder.Instance.Build(serverWithQuery, _apiKey, Logger, _correlationId);
+            var oRequest = AuthenticatedRequestBuilder.Instance.Build(serverWithQuery, _apiKey, Logger);
             oRequest.Method = "GET";
             oRequest.Timeout = _timeout*1000;
+
             try
             {
                 var oResponse = (HttpWebResponse) oRequest.GetResponse();
@@ -1586,7 +1583,7 @@ namespace Smartlogic.Semaphore.Api
         /// <exception cref="SemaphoreConnectionException"></exception>
         private T GetServerResponse<T>(Uri serverWithQuery) where T : class
         {
-            var oRequest = AuthenticatedRequestBuilder.Instance.Build(serverWithQuery, _apiKey, Logger, _correlationId);
+            var oRequest = AuthenticatedRequestBuilder.Instance.Build(serverWithQuery, _apiKey, Logger);
             oRequest.Method = "GET";
             oRequest.Timeout = _timeout*1000;
             var serializer = new XmlSerializer(typeof(T));
@@ -1648,4 +1645,3 @@ namespace Smartlogic.Semaphore.Api
         #endregion
     }
 }
-

--- a/src/Smartlogic.Semaphore.Api/SemanticEnhancement.cs
+++ b/src/Smartlogic.Semaphore.Api/SemanticEnhancement.cs
@@ -26,6 +26,7 @@ namespace Smartlogic.Semaphore.Api
         private readonly string _apiKey;
         private readonly Uri _serverUrl;
         private readonly int _timeout;
+        private readonly Guid _correlationId;
 
         /// <summary>
         ///     Constructs a SearchEnhancement class for use with communicating with a particular instance of Search Enhancement
@@ -94,9 +95,10 @@ namespace Smartlogic.Semaphore.Api
         /// </param>
         /// <param name="logger"></param>
         /// <param name="apiKey">An optional apikey string used for connecting to OAuth 2.0 secured services</param>
+        /// <param name="correlationId">An optional correlationId guid passed to SES for logging purposes to make it easier to trace a request</param>
         /// <exception cref="System.ArgumentException">Missing server Url;serverUrl</exception>
         /// <exception cref="ArgumentException"></exception>
-        public SemanticEnhancement(int webServiceTimeout, Uri serverUrl, ILogger logger, string apiKey = "") : this(webServiceTimeout, serverUrl, logger)
+        public SemanticEnhancement(int webServiceTimeout, Uri serverUrl, ILogger logger, string apiKey = "", Guid correlationId = default) : this(webServiceTimeout, serverUrl, logger)
         {
             if (!string.IsNullOrEmpty(apiKey))
             {
@@ -107,7 +109,9 @@ namespace Smartlogic.Semaphore.Api
                 }
             }
             _apiKey = apiKey;
+            _correlationId = correlationId;
         }
+
 
         /// <summary>
         ///     Gets or sets a value indicating whether exceptions should be thown or serialized and returned as XML or JSON. The
@@ -147,7 +151,7 @@ namespace Smartlogic.Semaphore.Api
 
             try
             {
-                WriteLow("SES Request: " + sb, null);
+                WriteMedium("SES Request: " + sb, null);
                 oDoc.LoadXml(GetServerResponse(new Uri(sb.ToString())));
             }
             catch (Exception oX)
@@ -222,7 +226,7 @@ namespace Smartlogic.Semaphore.Api
 
             try
             {
-                WriteLow("SES Request: " + sb, null);
+                WriteMedium("SES Request: " + sb, null);
                 oDoc.LoadXml(GetServerResponse(new Uri(sb.ToString())));
             }
             catch (Exception oX)
@@ -244,9 +248,9 @@ namespace Smartlogic.Semaphore.Api
         {
             var facets = new Dictionary<string, string>();
             var req = new Uri($"{_serverUrl}?TBDB={HttpUtility.UrlEncode(taxonomyIndex)}&TEMPLATE=service.xml&SERVICE=facetslist");
-            WriteLow("SES Request: " + req, null);
+            WriteMedium("SES Request: " + req, null);
 
-            var webRequest = AuthenticatedRequestBuilder.Instance.Build(req, _apiKey, Logger);
+            var webRequest = AuthenticatedRequestBuilder.Instance.Build(req, _apiKey, Logger, _correlationId);
             webRequest.Method = "GET";
             webRequest.Timeout = _timeout*1000;
 
@@ -335,7 +339,7 @@ namespace Smartlogic.Semaphore.Api
 
             try
             {
-                WriteLow("SES Request: " + sb, null);
+                WriteMedium("SES Request: " + sb, null);
                 result = GetServerResponse(new Uri(sb.ToString()));
             }
             catch (Exception oX)
@@ -409,7 +413,7 @@ namespace Smartlogic.Semaphore.Api
             string result;
             try
             {
-                WriteLow("SES Request: " + sb, null);
+                WriteMedium("SES Request: " + sb, null);
                 result = GetServerResponse(new Uri(sb.ToString()));
             }
             catch (Exception oX)
@@ -460,7 +464,7 @@ namespace Smartlogic.Semaphore.Api
 
             try
             {
-                WriteLow("SES Request: " + sb, null);
+                WriteMedium("SES Request: " + sb, null);
                 result = GetServerResponse(new Uri(sb.ToString()));
             }
             catch (Exception oX)
@@ -500,7 +504,7 @@ namespace Smartlogic.Semaphore.Api
 
             try
             {
-                WriteLow("SES Request: " + query, null);
+                WriteMedium("SES Request: " + query, null);
                 result = GetServerResponse(new Uri(query));
             }
             catch (Exception oX)
@@ -616,7 +620,7 @@ namespace Smartlogic.Semaphore.Api
 
             try
             {
-                WriteLow("SES Request: " + sb, null);
+                WriteMedium("SES Request: " + sb, null);
                 result = GetServerResponse(new Uri(sb.ToString()));
             }
             catch (Exception oX)
@@ -651,7 +655,7 @@ namespace Smartlogic.Semaphore.Api
             string result;
             try
             {
-                WriteLow("SES Request: " + sb, null);
+                WriteMedium("SES Request: " + sb, null);
                 result = GetServerResponse(new Uri(sb.ToString()));
             }
             catch (Exception oX)
@@ -701,7 +705,7 @@ namespace Smartlogic.Semaphore.Api
 
             try
             {
-                WriteLow("SES Request: " + sb, null);
+                WriteMedium("SES Request: " + sb, null);
                 result = GetServerResponse(new Uri(sb.ToString()));
             }
             catch (Exception oX)
@@ -752,7 +756,7 @@ namespace Smartlogic.Semaphore.Api
 
             try
             {
-                WriteLow("SES Request: " + sb, null);
+                WriteMedium("SES Request: " + sb, null);
                 oDoc.LoadXml(GetServerResponse(new Uri(sb.ToString())));
             }
             catch (Exception oX)
@@ -812,7 +816,7 @@ namespace Smartlogic.Semaphore.Api
 
             try
             {
-                WriteLow("SES Request: " + query, null);
+                WriteMedium("SES Request: " + query, null);
                 oDoc = XDocument.Parse(GetServerResponse(new Uri(query)));
             }
             catch (Exception oX)
@@ -965,7 +969,7 @@ namespace Smartlogic.Semaphore.Api
 
             try
             {
-                WriteLow("SES Request: {0}", restUri);
+                WriteMedium("SES Request: {0}", restUri);
                 var response = GetServerResponse<Schemas.Structure.Semaphore>(restUri);
                 return response?.Structure;
             }
@@ -988,9 +992,9 @@ namespace Smartlogic.Semaphore.Api
             var indices = new List<string>();
 
             var req = new Uri(_serverUrl + "?TEMPLATE=service.xml&SERVICE=modelslist");
-            WriteLow("SES Request: " + req, null);
+            WriteMedium("SES Request: " + req, null);
 
-            var oRequest = AuthenticatedRequestBuilder.Instance.Build(req, _apiKey, Logger);
+            var oRequest = AuthenticatedRequestBuilder.Instance.Build(req, _apiKey, Logger, _correlationId);
             oRequest.Method = "GET";
             oRequest.Timeout = _timeout*1000;
 
@@ -1049,9 +1053,9 @@ namespace Smartlogic.Semaphore.Api
             var languages = new List<string>();
 
             var req = new Uri(_serverUrl + "?TEMPLATE=service.xml&SERVICE=modelslist");
-            WriteLow("SES Request: " + req, null);
+            WriteMedium("SES Request: " + req, null);
 
-            var oRequest = AuthenticatedRequestBuilder.Instance.Build(req, _apiKey, Logger);
+            var oRequest = AuthenticatedRequestBuilder.Instance.Build(req, _apiKey, Logger, _correlationId);
             oRequest.Method = "GET";
             oRequest.Timeout = _timeout * 1000;
 
@@ -1227,7 +1231,7 @@ namespace Smartlogic.Semaphore.Api
 
             try
             {
-                WriteLow("SES Request: " + sb, null);
+                WriteMedium("SES Request: " + sb, null);
                 oDoc.LoadXml(GetServerResponse(new Uri(sb.ToString())));
             }
             catch (Exception oX)
@@ -1263,7 +1267,7 @@ namespace Smartlogic.Semaphore.Api
 
             try
             {
-                WriteLow("SES Request: " + sb, null);
+                WriteMedium("SES Request: " + sb, null);
                 oDoc.LoadXml(GetServerResponse(new Uri(sb.ToString())));
             }
             catch (Exception oX)
@@ -1317,7 +1321,7 @@ namespace Smartlogic.Semaphore.Api
 
             try
             {
-                WriteLow("SES Request: " + sb, null);
+                WriteMedium("SES Request: " + sb, null);
                 oDoc.LoadXml(GetServerResponse(new Uri(sb.ToString())));
             }
             catch (Exception oX)
@@ -1339,7 +1343,7 @@ namespace Smartlogic.Semaphore.Api
             string response = null;
 
             var req = new Uri(_serverUrl + "?TEMPLATE=service.xml&SERVICE=versions");
-            WriteLow("SES Request: " + req, null);
+            WriteMedium("SES Request: " + req, null);
 
             try
             {
@@ -1448,7 +1452,7 @@ namespace Smartlogic.Semaphore.Api
 
             try
             {
-                WriteLow("SES Request: " + query, null);
+                WriteMedium("SES Request: " + query, null);
                 return GetServerResponse(new Uri(query));
             }
             catch (Exception oX)
@@ -1538,10 +1542,9 @@ namespace Smartlogic.Semaphore.Api
         /// <exception cref="SemaphoreConnectionException"></exception>
         private string GetServerResponse(Uri serverWithQuery)
         {
-            var oRequest = AuthenticatedRequestBuilder.Instance.Build(serverWithQuery, _apiKey, Logger);
+            var oRequest = AuthenticatedRequestBuilder.Instance.Build(serverWithQuery, _apiKey, Logger, _correlationId);
             oRequest.Method = "GET";
             oRequest.Timeout = _timeout*1000;
-
             try
             {
                 var oResponse = (HttpWebResponse) oRequest.GetResponse();
@@ -1583,7 +1586,7 @@ namespace Smartlogic.Semaphore.Api
         /// <exception cref="SemaphoreConnectionException"></exception>
         private T GetServerResponse<T>(Uri serverWithQuery) where T : class
         {
-            var oRequest = AuthenticatedRequestBuilder.Instance.Build(serverWithQuery, _apiKey, Logger);
+            var oRequest = AuthenticatedRequestBuilder.Instance.Build(serverWithQuery, _apiKey, Logger, _correlationId);
             oRequest.Method = "GET";
             oRequest.Timeout = _timeout*1000;
             var serializer = new XmlSerializer(typeof(T));

--- a/src/Smartlogic.Semaphore.Api/SemanticEnhancement.cs
+++ b/src/Smartlogic.Semaphore.Api/SemanticEnhancement.cs
@@ -26,6 +26,7 @@ namespace Smartlogic.Semaphore.Api
         private readonly string _apiKey;
         private readonly Uri _serverUrl;
         private readonly int _timeout;
+        private readonly Guid _correlationId;
 
         /// <summary>
         ///     Constructs a SearchEnhancement class for use with communicating with a particular instance of Search Enhancement
@@ -94,9 +95,10 @@ namespace Smartlogic.Semaphore.Api
         /// </param>
         /// <param name="logger"></param>
         /// <param name="apiKey">An optional apikey string used for connecting to OAuth 2.0 secured services</param>
+        /// <param name="correlationId">An optional correlationId guid used in logs for better identification</param>
         /// <exception cref="System.ArgumentException">Missing server Url;serverUrl</exception>
         /// <exception cref="ArgumentException"></exception>
-        public SemanticEnhancement(int webServiceTimeout, Uri serverUrl, ILogger logger, string apiKey = "") : this(webServiceTimeout, serverUrl, logger)
+        public SemanticEnhancement(int webServiceTimeout, Uri serverUrl, ILogger logger, string apiKey = "", Guid correlationId = default) : this(webServiceTimeout, serverUrl, logger)
         {
             if (!string.IsNullOrEmpty(apiKey))
             {
@@ -107,7 +109,9 @@ namespace Smartlogic.Semaphore.Api
                 }
             }
             _apiKey = apiKey;
+            _correlationId = correlationId;
         }
+
 
         /// <summary>
         ///     Gets or sets a value indicating whether exceptions should be thown or serialized and returned as XML or JSON. The
@@ -147,7 +151,7 @@ namespace Smartlogic.Semaphore.Api
 
             try
             {
-                WriteLow("SES Request: " + sb, null);
+                WriteMedium("SES Request: " + sb, null);
                 oDoc.LoadXml(GetServerResponse(new Uri(sb.ToString())));
             }
             catch (Exception oX)
@@ -222,7 +226,7 @@ namespace Smartlogic.Semaphore.Api
 
             try
             {
-                WriteLow("SES Request: " + sb, null);
+                WriteMedium("SES Request: " + sb, null);
                 oDoc.LoadXml(GetServerResponse(new Uri(sb.ToString())));
             }
             catch (Exception oX)
@@ -244,9 +248,9 @@ namespace Smartlogic.Semaphore.Api
         {
             var facets = new Dictionary<string, string>();
             var req = new Uri($"{_serverUrl}?TBDB={HttpUtility.UrlEncode(taxonomyIndex)}&TEMPLATE=service.xml&SERVICE=facetslist");
-            WriteLow("SES Request: " + req, null);
+            WriteMedium("SES Request: " + req, null);
 
-            var webRequest = AuthenticatedRequestBuilder.Instance.Build(req, _apiKey, Logger);
+            var webRequest = AuthenticatedRequestBuilder.Instance.Build(req, _apiKey, Logger, _correlationId);
             webRequest.Method = "GET";
             webRequest.Timeout = _timeout*1000;
 
@@ -335,7 +339,7 @@ namespace Smartlogic.Semaphore.Api
 
             try
             {
-                WriteLow("SES Request: " + sb, null);
+                WriteMedium("SES Request: " + sb, null);
                 result = GetServerResponse(new Uri(sb.ToString()));
             }
             catch (Exception oX)
@@ -409,7 +413,7 @@ namespace Smartlogic.Semaphore.Api
             string result;
             try
             {
-                WriteLow("SES Request: " + sb, null);
+                WriteMedium("SES Request: " + sb, null);
                 result = GetServerResponse(new Uri(sb.ToString()));
             }
             catch (Exception oX)
@@ -460,7 +464,7 @@ namespace Smartlogic.Semaphore.Api
 
             try
             {
-                WriteLow("SES Request: " + sb, null);
+                WriteMedium("SES Request: " + sb, null);
                 result = GetServerResponse(new Uri(sb.ToString()));
             }
             catch (Exception oX)
@@ -500,7 +504,7 @@ namespace Smartlogic.Semaphore.Api
 
             try
             {
-                WriteLow("SES Request: " + query, null);
+                WriteMedium("SES Request: " + query, null);
                 result = GetServerResponse(new Uri(query));
             }
             catch (Exception oX)
@@ -616,7 +620,7 @@ namespace Smartlogic.Semaphore.Api
 
             try
             {
-                WriteLow("SES Request: " + sb, null);
+                WriteMedium("SES Request: " + sb, null);
                 result = GetServerResponse(new Uri(sb.ToString()));
             }
             catch (Exception oX)
@@ -651,7 +655,7 @@ namespace Smartlogic.Semaphore.Api
             string result;
             try
             {
-                WriteLow("SES Request: " + sb, null);
+                WriteMedium("SES Request: " + sb, null);
                 result = GetServerResponse(new Uri(sb.ToString()));
             }
             catch (Exception oX)
@@ -701,7 +705,7 @@ namespace Smartlogic.Semaphore.Api
 
             try
             {
-                WriteLow("SES Request: " + sb, null);
+                WriteMedium("SES Request: " + sb, null);
                 result = GetServerResponse(new Uri(sb.ToString()));
             }
             catch (Exception oX)
@@ -752,7 +756,7 @@ namespace Smartlogic.Semaphore.Api
 
             try
             {
-                WriteLow("SES Request: " + sb, null);
+                WriteMedium("SES Request: " + sb, null);
                 oDoc.LoadXml(GetServerResponse(new Uri(sb.ToString())));
             }
             catch (Exception oX)
@@ -812,7 +816,7 @@ namespace Smartlogic.Semaphore.Api
 
             try
             {
-                WriteLow("SES Request: " + query, null);
+                WriteMedium("SES Request: " + query, null);
                 oDoc = XDocument.Parse(GetServerResponse(new Uri(query)));
             }
             catch (Exception oX)
@@ -965,7 +969,7 @@ namespace Smartlogic.Semaphore.Api
 
             try
             {
-                WriteLow("SES Request: {0}", restUri);
+                WriteMedium("SES Request: {0}", restUri);
                 var response = GetServerResponse<Schemas.Structure.Semaphore>(restUri);
                 return response?.Structure;
             }
@@ -988,9 +992,9 @@ namespace Smartlogic.Semaphore.Api
             var indices = new List<string>();
 
             var req = new Uri(_serverUrl + "?TEMPLATE=service.xml&SERVICE=modelslist");
-            WriteLow("SES Request: " + req, null);
+            WriteMedium("SES Request: " + req, null);
 
-            var oRequest = AuthenticatedRequestBuilder.Instance.Build(req, _apiKey, Logger);
+            var oRequest = AuthenticatedRequestBuilder.Instance.Build(req, _apiKey, Logger, _correlationId);
             oRequest.Method = "GET";
             oRequest.Timeout = _timeout*1000;
 
@@ -1049,9 +1053,9 @@ namespace Smartlogic.Semaphore.Api
             var languages = new List<string>();
 
             var req = new Uri(_serverUrl + "?TEMPLATE=service.xml&SERVICE=modelslist");
-            WriteLow("SES Request: " + req, null);
+            WriteMedium("SES Request: " + req, null);
 
-            var oRequest = AuthenticatedRequestBuilder.Instance.Build(req, _apiKey, Logger);
+            var oRequest = AuthenticatedRequestBuilder.Instance.Build(req, _apiKey, Logger, _correlationId);
             oRequest.Method = "GET";
             oRequest.Timeout = _timeout * 1000;
 
@@ -1227,7 +1231,7 @@ namespace Smartlogic.Semaphore.Api
 
             try
             {
-                WriteLow("SES Request: " + sb, null);
+                WriteMedium("SES Request: " + sb, null);
                 oDoc.LoadXml(GetServerResponse(new Uri(sb.ToString())));
             }
             catch (Exception oX)
@@ -1263,7 +1267,7 @@ namespace Smartlogic.Semaphore.Api
 
             try
             {
-                WriteLow("SES Request: " + sb, null);
+                WriteMedium("SES Request: " + sb, null);
                 oDoc.LoadXml(GetServerResponse(new Uri(sb.ToString())));
             }
             catch (Exception oX)
@@ -1317,7 +1321,7 @@ namespace Smartlogic.Semaphore.Api
 
             try
             {
-                WriteLow("SES Request: " + sb, null);
+                WriteMedium("SES Request: " + sb, null);
                 oDoc.LoadXml(GetServerResponse(new Uri(sb.ToString())));
             }
             catch (Exception oX)
@@ -1339,7 +1343,7 @@ namespace Smartlogic.Semaphore.Api
             string response = null;
 
             var req = new Uri(_serverUrl + "?TEMPLATE=service.xml&SERVICE=versions");
-            WriteLow("SES Request: " + req, null);
+            WriteMedium("SES Request: " + req, null);
 
             try
             {
@@ -1448,7 +1452,7 @@ namespace Smartlogic.Semaphore.Api
 
             try
             {
-                WriteLow("SES Request: " + query, null);
+                WriteMedium("SES Request: " + query, null);
                 return GetServerResponse(new Uri(query));
             }
             catch (Exception oX)
@@ -1538,10 +1542,9 @@ namespace Smartlogic.Semaphore.Api
         /// <exception cref="SemaphoreConnectionException"></exception>
         private string GetServerResponse(Uri serverWithQuery)
         {
-            var oRequest = AuthenticatedRequestBuilder.Instance.Build(serverWithQuery, _apiKey, Logger);
+            var oRequest = AuthenticatedRequestBuilder.Instance.Build(serverWithQuery, _apiKey, Logger, _correlationId);
             oRequest.Method = "GET";
             oRequest.Timeout = _timeout*1000;
-
             try
             {
                 var oResponse = (HttpWebResponse) oRequest.GetResponse();
@@ -1583,7 +1586,7 @@ namespace Smartlogic.Semaphore.Api
         /// <exception cref="SemaphoreConnectionException"></exception>
         private T GetServerResponse<T>(Uri serverWithQuery) where T : class
         {
-            var oRequest = AuthenticatedRequestBuilder.Instance.Build(serverWithQuery, _apiKey, Logger);
+            var oRequest = AuthenticatedRequestBuilder.Instance.Build(serverWithQuery, _apiKey, Logger, _correlationId);
             oRequest.Method = "GET";
             oRequest.Timeout = _timeout*1000;
             var serializer = new XmlSerializer(typeof(T));
@@ -1645,3 +1648,4 @@ namespace Smartlogic.Semaphore.Api
         #endregion
     }
 }
+

--- a/src/Smartlogic.Semaphore.Api/Smartlogic.Semaphore.Api.csproj
+++ b/src/Smartlogic.Semaphore.Api/Smartlogic.Semaphore.Api.csproj
@@ -2,15 +2,15 @@
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
-    <Company>Smartlogic Semaphore Ltd</Company>
-    <Product>Smartlogic Semaphore .</Product>
-    <Copyright>Copyright © Smartlogic Semaphore Ltd 2020</Copyright>
+    <Company>MarkLogic Corporation</Company>
+    <Product>Semaphore by MarkLogic</Product>
+    <Copyright>Copyright © MarkLogic Corporation 2023</Copyright>
     <Description>A client library that can be used to connect to Semaphore services from Microsoft .Net framework applications</Description>
     <PackageId>Smartlogic.Semaphore.Api</PackageId>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <Authors>Smartlogic Semaphore Ltd</Authors>
-    <AssemblyVersion>1.1.21.0</AssemblyVersion>
-    <Version>1.1.21</Version>
+    <Authors>MarkLogic Corporation</Authors>
+    <AssemblyVersion>1.1.22.0</AssemblyVersion>
+    <Version>1.1.22</Version>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>key.snk</AssemblyOriginatorKeyFile>
   </PropertyGroup>

--- a/src/Smartlogic.Semaphore.Api/Smartlogic.Semaphore.Api.csproj
+++ b/src/Smartlogic.Semaphore.Api/Smartlogic.Semaphore.Api.csproj
@@ -2,15 +2,15 @@
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
-    <Company>MarkLogic Corporation</Company>
-    <Product>Semaphore by MarkLogic</Product>
-    <Copyright>Copyright © MarkLogic Corporation 2023</Copyright>
+    <Company>Smartlogic Semaphore Ltd</Company>
+    <Product>Smartlogic Semaphore .</Product>
+    <Copyright>Copyright © Smartlogic Semaphore Ltd 2020</Copyright>
     <Description>A client library that can be used to connect to Semaphore services from Microsoft .Net framework applications</Description>
     <PackageId>Smartlogic.Semaphore.Api</PackageId>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <Authors>MarkLogic Corporation</Authors>
-    <AssemblyVersion>1.1.22.0</AssemblyVersion>
-    <Version>1.1.22</Version>
+    <Authors>Smartlogic Semaphore Ltd</Authors>
+    <AssemblyVersion>1.1.21.0</AssemblyVersion>
+    <Version>1.1.21</Version>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>key.snk</AssemblyOriginatorKeyFile>
   </PropertyGroup>


### PR DESCRIPTION
Adding option to pass correlation Id when creating CS/SES client instances, that will then get passed as a header in all requests.
Increasing log levels for request logging.
Changing project file to use MarkLogic instead of Smartlogic.
